### PR TITLE
Implementação de testes para os métodos hasMinLen e hasMaxLen

### DIFF
--- a/tests/validation-contract.spec.js
+++ b/tests/validation-contract.spec.js
@@ -5,17 +5,52 @@
     const contract = require('../validation-contract.js');
 
     describe('Fluent Validator', () => {
+
         describe('"Is Required"', () => {
             it('should return an error when value is invalid', async () => {
                 await contract.clear();
                 await contract.isRequired('', 'This field is required');
-                expect(contract.errors.length).equal(1);
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(1);
             });
 
             it('should return no errors when value is valid', async () => {
-                await contract.clear();                
+                await contract.clear();
                 await contract.isRequired('Some value', 'This field is required');
-                expect(contract.errors.length).equal(0);
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(0);
+            });
+        });
+
+        describe('"Has Min Length"', () => {
+            it('should return an error when value is invalid', async () => {
+                await contract.clear();
+                await contract.hasMinLen('', 3, 'This field is required');
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(1);
+            });
+
+            it('should return an error when value is invalid different of empty', async () => {
+                await contract.clear();
+                await contract.hasMinLen('Some value', 11, 'This field is required and more than 11');
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(1);
+            });
+        });
+
+        describe('"Has Max Length"', () => {
+            it('should return an error when value is invalid', async () => {
+                await contract.clear();
+                await contract.hasMaxLen('', 3, 'This field is required');
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(1);
+            });
+
+            it('should return an error when value is invalid different of empty', async () => {
+                await contract.clear();
+                await contract.hasMaxLen('Some value', 9, 'This field is required and less than 10');
+                let errors = await contract.getErrors();
+                expect(errors.length).equal(1);
             });
         });
     });

--- a/validation-contract.js
+++ b/validation-contract.js
@@ -25,7 +25,7 @@
     // IsEmail
 
 
-    exports.errors = errors;
+    exports.getErrors = async () => errors;
 
     exports.clear = async () => {
         errors = [];


### PR DESCRIPTION
Foi realizada alteração da forma de obter a lista com as mensagens de erro para corrigir um problema com o estado da variável `errors`. O problema estava fazendo com que alguns testes já implementos falhassem.